### PR TITLE
Bugfix: don't print error if there is no text

### DIFF
--- a/helpers/cli/cli.go
+++ b/helpers/cli/cli.go
@@ -37,6 +37,8 @@ func OnUsageError(context *cli.Context, err error, isSubcommand bool) error {
 // ExitErrHandler implements cli.ExitErrHandlerFunc
 // we make it simple, we always return exit code 1
 func ExitErrHandler(_ *cli.Context, err error) {
-	fmt.Fprintf(cli.ErrWriter, "Error: %+v\n", err) // nolint: errcheck
+	if err.Error() != "" {
+		fmt.Fprintf(cli.ErrWriter, "Error: %+v\n", err) // nolint: errcheck
+	}
 	cli.OsExiter(1)
 }


### PR DESCRIPTION
e.g. when we display the usage because of wrong flag, we do cli.NewExitError and this results to the ExitErrHandler call and prints empty "Error:" on the last line