### PR TITLE
Fix: display custom err message by missing repo

### DIFF
--- a/connectors/github/github.go
+++ b/connectors/github/github.go
@@ -60,13 +60,14 @@ func formatErrorCode(query string, err error) error {
 func (c *Connector) RepositoryExists() (bool, error) {
 	_, resp, err := c.client.Repositories.Get(c.context, c.Owner, c.Repo)
 	if err != nil {
+		if resp.StatusCode == 404 { // not found isn't an error
+			return false, nil
+		}
 		return false, formatErrorCode("RepositoryExists", err)
 	}
 	switch resp.StatusCode {
 	case 200:
 		return true, nil
-	case 404:
-		return false, nil
 	default:
 		return false, formatErrorCode(
 			"RepositoryExists",

--- a/connectors/github/github_test.go
+++ b/connectors/github/github_test.go
@@ -76,6 +76,7 @@ func TestConnector_RepositoryExists(t *testing.T) {
 			name: "API returns 404",
 			returnValue: testclient.ReturnValueStr{
 				RetRepoServiceGetRespCode: 404,
+				RetRepoServiceGetErr:      true,
 			},
 			want: false,
 		},

--- a/connectors/github/internal/testclient/testclient.go
+++ b/connectors/github/internal/testclient/testclient.go
@@ -101,17 +101,19 @@ func (g *GitHubRepoService) Get(
 	ctx context.Context,
 	owner, repo string) (*github.Repository, *github.Response, error) {
 
-	if g.ReturnValue.RetRepoServiceGetErr {
-		return nil, nil, fmt.Errorf("can't fetch the repo data")
-	}
-
 	//if return code not defined, return 200 for Ok
 	respCode := 200
 	if g.ReturnValue.RetRepoServiceGetRespCode != 0 {
 		respCode = g.ReturnValue.RetRepoServiceGetRespCode
 	}
 
-	return nil, genResponse(respCode), nil
+	response := genResponse(respCode)
+
+	if g.ReturnValue.RetRepoServiceGetErr {
+		return nil, response, fmt.Errorf("can't fetch the repo data")
+	}
+
+	return nil, response, nil
 }
 
 // GitHubIssueService simulates the github.IssuesService


### PR DESCRIPTION
404 causes err to be returned, so we have to carry it properly

Signed-off-by: Artem Sidorenko <artem@posteo.de>