### PR TITLE
Fix: follow the good pipeline patterns

### DIFF
--- a/cli/commands/generate/progress.go
+++ b/cli/commands/generate/progress.go
@@ -29,21 +29,13 @@ import (
 func printProgress( // nolint: gocyclo
 	ctx context.Context,
 	out io.Writer,
-) (
-	ctagscounter chan<- bool,
-	cmaxtags chan<- int,
-	cissuescounter chan<- bool,
-	cmaxissues chan<- int,
-	cmrscounter chan<- bool,
-	cmaxmrs chan<- int,
+	ctagscounter <-chan bool,
+	cmaxtags <-chan int,
+	cissuescounter <-chan bool,
+	cmaxissues <-chan int,
+	cmrscounter <-chan bool,
+	cmaxmrs <-chan int,
 ) {
-	lctagscounter := make(chan bool)
-	lcmaxtags := make(chan int)
-	lcissuescounter := make(chan bool)
-	lcmaxissues := make(chan int)
-	lmrscounter := make(chan bool)
-	lcmaxmrs := make(chan int)
-
 	go func() {
 		var tagscounter int
 		var issuescounter int
@@ -61,46 +53,47 @@ func printProgress( // nolint: gocyclo
 			select {
 			case <-ctx.Done():
 				return
-			case _, ok := <-lctagscounter:
+			case _, ok := <-ctagscounter:
 				if ok {
 					tagscounter++
 				} else {
-					lctagscounter = nil
+					ctagscounter = nil
 				}
-			case v, ok := <-lcmaxtags:
+			case v, ok := <-cmaxtags:
 				if ok {
 					maxtags = strconv.Itoa(v)
 				} else {
-					lcmaxtags = nil
+					cmaxtags = nil
 				}
-			case _, ok := <-lcissuescounter:
+			case _, ok := <-cissuescounter:
 				if ok {
 					issuescounter++
 				} else {
-					lcissuescounter = nil
+					cissuescounter = nil
 				}
-			case v, ok := <-lcmaxissues:
+			case v, ok := <-cmaxissues:
 				if ok {
 					maxissues = strconv.Itoa(v)
 				} else {
-					lcmaxissues = nil
+					cmaxissues = nil
 				}
-			case _, ok := <-lmrscounter:
+			case _, ok := <-cmrscounter:
 				if ok {
 					mrscounter++
 				} else {
-					lmrscounter = nil
+					cmrscounter = nil
 				}
-			case v, ok := <-lcmaxmrs:
+			case v, ok := <-cmaxmrs:
 				if ok {
 					maxmrs = strconv.Itoa(v)
 				} else {
-					lcmaxmrs = nil
+					cmaxmrs = nil
 				}
 			}
 
-			if lctagscounter == nil && lcmaxtags == nil &&
-				lcissuescounter == nil && lcmaxissues == nil && lmrscounter == nil && lcmaxmrs == nil {
+			if ctagscounter == nil && cmaxtags == nil &&
+				cissuescounter == nil && cmaxissues == nil &&
+				cmrscounter == nil && cmaxmrs == nil {
 				return
 			}
 
@@ -112,8 +105,4 @@ func printProgress( // nolint: gocyclo
 			)
 		}
 	}()
-
-	return lctagscounter, lcmaxtags,
-		lcissuescounter, lcmaxissues,
-		lmrscounter, lcmaxmrs
 }

--- a/connectors/connectors_test.go
+++ b/connectors/connectors_test.go
@@ -30,14 +30,14 @@ import (
 
 type testConnector struct{}
 
-func (t *testConnector) Tags(_ context.Context, _ chan<- error, _ chan<- int) <-chan data.Tag {
-	return nil
+func (t *testConnector) Tags(_ context.Context, _ chan<- error) (<-chan data.Tag, <-chan int) {
+	return nil, nil
 }
-func (t *testConnector) Issues(_ context.Context, _ chan<- error, _ chan<- int) <-chan data.Issue {
-	return nil
+func (t *testConnector) Issues(_ context.Context, _ chan<- error) (<-chan data.Issue, <-chan int) {
+	return nil, nil
 }
-func (t *testConnector) MRs(_ context.Context, _ chan<- error, _ chan<- int) <-chan data.MR {
-	return nil
+func (t *testConnector) MRs(_ context.Context, _ chan<- error) (<-chan data.MR, <-chan int) {
+	return nil, nil
 }
 func (t *testConnector) GetNewTagURL(string) (string, error) { return "", nil }
 func (t *testConnector) RepositoryExists() (bool, error)     { return true, nil }

--- a/connectors/github/issues.go
+++ b/connectors/github/issues.go
@@ -31,14 +31,14 @@ import (
 func (c *Connector) Issues(
 	ctx context.Context,
 	cerr chan<- error,
-	cmaxissues chan<- int,
 ) (
 	ctags <-chan data.Issue,
+	cmaxissues <-chan int,
 ) {
 	issues := c.listIssues(ctx, cerr)
 	dissues := c.processIssues(ctx, cerr, issues)
 
-	return dissues
+	return dissues, nil
 }
 
 func (c *Connector) listIssues(

--- a/connectors/github/issues_test.go
+++ b/connectors/github/issues_test.go
@@ -59,7 +59,7 @@ func TestConnector_Issues(t *testing.T) {
 			c := setupTestConnector(tt.returnValue, false)
 			cerr := make(chan error, 1)
 
-			cgot := c.Issues(context.Background(), cerr, nil)
+			cgot, _ := c.Issues(context.Background(), cerr)
 			var got data.Issues
 			for t := range cgot {
 				got = append(got, t)

--- a/connectors/github/prs.go
+++ b/connectors/github/prs.go
@@ -32,14 +32,14 @@ import (
 func (c *Connector) MRs(
 	ctx context.Context,
 	cerr chan<- error,
-	cmaxmrs chan<- int,
 ) (
 	cmrs <-chan data.MR,
+	cmaxmrs <-chan int,
 ) {
 	mrs := c.listPRs(ctx, cerr)
 	dmrs := c.processPRs(ctx, cerr, mrs)
 
-	return dmrs
+	return dmrs, nil
 }
 
 func (c *Connector) listPRs(

--- a/connectors/github/prs_test.go
+++ b/connectors/github/prs_test.go
@@ -61,7 +61,7 @@ func TestConnector_MRs(t *testing.T) {
 			c := setupTestConnector(tt.returnValue, false)
 			cerr := make(chan error, 1)
 
-			cgot := c.MRs(context.Background(), cerr, nil)
+			cgot, _ := c.MRs(context.Background(), cerr)
 			var got data.MRs
 			for t := range cgot {
 				got = append(got, t)

--- a/connectors/github/tags.go
+++ b/connectors/github/tags.go
@@ -32,14 +32,14 @@ import (
 func (c *Connector) Tags(
 	ctx context.Context,
 	cerr chan<- error,
-	cmaxtags chan<- int,
 ) (
 	ctags <-chan data.Tag,
+	cmaxtags <-chan int,
 ) {
 	tags := c.listTags(ctx, cerr)
 	dtags := c.processTags(ctx, cerr, tags)
 
-	return dtags
+	return dtags, nil
 }
 
 // listTags gets the tags from GitHub client and returns them via channel

--- a/connectors/github/tags_test.go
+++ b/connectors/github/tags_test.go
@@ -71,7 +71,7 @@ func TestConnector_Tags(t *testing.T) {
 			c := setupTestConnector(tt.returnValue, false)
 			cerr := make(chan error, 1)
 
-			cgot := c.Tags(context.Background(), cerr, nil)
+			cgot, _ := c.Tags(context.Background(), cerr)
 			var got data.Tags
 			for t := range cgot {
 				got = append(got, t)

--- a/connectors/interface.go
+++ b/connectors/interface.go
@@ -27,23 +27,23 @@ type Connector interface {
 	Tags(
 		ctx context.Context,
 		cerr chan<- error,
-		cmaxtags chan<- int,
 	) (
 		ctags <-chan data.Tag,
+		cmaxtags <-chan int,
 	)
 	Issues(
 		ctx context.Context,
 		cerr chan<- error,
-		cmaxissues chan<- int,
 	) (
 		cissues <-chan data.Issue,
+		cmaxissues <-chan int,
 	)
 	MRs(
 		ctx context.Context,
 		cerr chan<- error,
-		cmaxmrs chan<- int,
 	) (
 		cmr <-chan data.MR,
+		cmaxmrs <-chan int,
 	)
 	GetNewTagURL(string) (string, error)
 	RepositoryExists() (bool, error)

--- a/internal/testing/testconnector/testconnector.go
+++ b/internal/testing/testconnector/testconnector.go
@@ -51,8 +51,10 @@ func (c *Connector) RepositoryExists() (bool, error) {
 func (c *Connector) Tags(
 	_ context.Context,
 	cerr chan<- error,
-	cmaxtags chan<- int,
-) <-chan data.Tag {
+) (
+	<-chan data.Tag,
+	<-chan int,
+) {
 	tags := testdata.Tags()
 
 	if RetTestingTag {
@@ -74,15 +76,17 @@ func (c *Connector) Tags(
 		}
 	}()
 
-	return ctags
+	return ctags, nil
 }
 
 // Issues implements the connectors.Connector interface
 func (c *Connector) Issues(
 	_ context.Context,
 	cerr chan<- error,
-	cmaxissues chan<- int,
-) <-chan data.Issue {
+) (
+	<-chan data.Issue,
+	<-chan int,
+) {
 	cissues := make(chan data.Issue)
 
 	go func() {
@@ -93,15 +97,17 @@ func (c *Connector) Issues(
 		}
 	}()
 
-	return cissues
+	return cissues, nil
 }
 
 // MRs implements the connectors.Connector interface
 func (c *Connector) MRs(
 	_ context.Context,
 	cerr chan<- error,
-	cmaxmrs chan<- int,
-) <-chan data.MR {
+) (
+	<-chan data.MR,
+	<-chan int,
+) {
 	cmrs := make(chan data.MR)
 
 	go func() {
@@ -112,7 +118,7 @@ func (c *Connector) MRs(
 		}
 	}()
 
-	return cmrs
+	return cmrs, nil
 }
 
 // GetNewTagURL implements the connectors.Connector interface


### PR DESCRIPTION
> stages close their outbound channels when all the send operations are done.
> stages keep receiving values from inbound channels until those channels are closed.

from https://blog.golang.org/pipelines

Besides that, from now on there is another pattern:
- if func returns a channel, this func pushes data to it and closes it
- if func gets a channel passed, it consumes the data until it closed
- func with passed channel, might pass data to it only in exceptional cases (like counters here). In this case the channel should be created&closed outside of the func, ideally in the sequentional flow (like counters here)

Otherwise we potentially run into strange handling problems "who is going to close the channel" and "why somebody is sending to the closed channel"

Signed-off-by: Artem Sidorenko <artem@posteo.de>