### PR TITLE
Testing fix: use the same setup for coverage calc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: ## Run the tests
 	go test -timeout 10s -race -cpu 4 -count 1 $$(go list ./... | grep -v /vendor/)
 	gometalinter --enable-all --disable=dupl --deadline=300s --line-length=100 -s vendor ./...
 # calculate the coverage only if everything was ok (see go test, coverage can have side effects)
-	go test -timeout 10s -cover  $$(go list ./... | grep -v /vendor/)
+	go test -timeout 10s -cover -race -cpu 4 -count 1  $$(go list ./... | grep -v /vendor/)
 
 prepare-release: ## Prepare a new release
 ifndef NEW_VERSION


### PR DESCRIPTION
otherwise we have different timings and IO blocks, this results to
the different channel situations and scheduling of goroutines. In the end
we have passing normal tests, but failing tests with coverage because of that.
Sometimes its even randomly unstable flapping.

Signed-off-by: Artem Sidorenko <artem@posteo.de>