### PR TITLE
Improvement: lets have the max counters first

### DIFF
--- a/cli/commands/generate/progress.go
+++ b/cli/commands/generate/progress.go
@@ -53,23 +53,11 @@ func printProgress( // nolint: gocyclo
 			select {
 			case <-ctx.Done():
 				return
-			case _, ok := <-ctagscounter:
-				if ok {
-					tagscounter++
-				} else {
-					ctagscounter = nil
-				}
 			case v, ok := <-cmaxtags:
 				if ok {
 					maxtags = strconv.Itoa(v)
 				} else {
 					cmaxtags = nil
-				}
-			case _, ok := <-cissuescounter:
-				if ok {
-					issuescounter++
-				} else {
-					cissuescounter = nil
 				}
 			case v, ok := <-cmaxissues:
 				if ok {
@@ -77,17 +65,29 @@ func printProgress( // nolint: gocyclo
 				} else {
 					cmaxissues = nil
 				}
-			case _, ok := <-cmrscounter:
-				if ok {
-					mrscounter++
-				} else {
-					cmrscounter = nil
-				}
 			case v, ok := <-cmaxmrs:
 				if ok {
 					maxmrs = strconv.Itoa(v)
 				} else {
 					cmaxmrs = nil
+				}
+			case _, ok := <-ctagscounter:
+				if ok {
+					tagscounter++
+				} else {
+					ctagscounter = nil
+				}
+			case _, ok := <-cissuescounter:
+				if ok {
+					issuescounter++
+				} else {
+					cissuescounter = nil
+				}
+			case _, ok := <-cmrscounter:
+				if ok {
+					mrscounter++
+				} else {
+					cmrscounter = nil
 				}
 			}
 


### PR DESCRIPTION
this enables (how it looks like) a faster proceeding of this channels with select, so we get the max information on the progress much faster

Signed-off-by: Artem Sidorenko <artem@posteo.de>